### PR TITLE
HOTFIX: Production needs @types/react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "benweare.com",
             "version": "0.1.0",
             "dependencies": {
+                "@types/react": "^18.0.17",
                 "animate.css": "^4.1.1",
                 "autoprefixer": "^10.4.7",
                 "axios": "^0.27.2",
@@ -37,7 +38,6 @@
                 "@types/jest": "^28.1.7",
                 "@types/jsdom": "^20.0.0",
                 "@types/node": "^18.7.6",
-                "@types/react": "^18.0.15",
                 "@types/react-dom": "^18.0.6",
                 "@types/swagger-ui-dist": "^3.30.1",
                 "@typescript-eslint/eslint-plugin": "^5.33.1",
@@ -4433,8 +4433,7 @@
         "node_modules/@types/prop-types": {
             "version": "15.7.5",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-            "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-            "dev": true
+            "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
         },
         "node_modules/@types/q": {
             "version": "1.5.5",
@@ -4452,10 +4451,9 @@
             "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
         },
         "node_modules/@types/react": {
-            "version": "18.0.15",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.15.tgz",
-            "integrity": "sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==",
-            "dev": true,
+            "version": "18.0.17",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.17.tgz",
+            "integrity": "sha512-38ETy4tL+rn4uQQi7mB81G7V1g0u2ryquNmsVIOKUAEIDK+3CUjZ6rSRpdvS99dNBnkLFL83qfmtLacGOTIhwQ==",
             "dependencies": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -4487,8 +4485,7 @@
         "node_modules/@types/scheduler": {
             "version": "0.16.2",
             "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-            "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-            "dev": true
+            "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
         },
         "node_modules/@types/serve-index": {
             "version": "1.9.1",
@@ -7033,8 +7030,7 @@
         "node_modules/csstype": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
-            "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
-            "dev": true
+            "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
         },
         "node_modules/damerau-levenshtein": {
             "version": "1.0.8",
@@ -23967,8 +23963,7 @@
         "@types/prop-types": {
             "version": "15.7.5",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-            "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-            "dev": true
+            "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
         },
         "@types/q": {
             "version": "1.5.5",
@@ -23986,10 +23981,9 @@
             "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
         },
         "@types/react": {
-            "version": "18.0.15",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.15.tgz",
-            "integrity": "sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==",
-            "dev": true,
+            "version": "18.0.17",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.17.tgz",
+            "integrity": "sha512-38ETy4tL+rn4uQQi7mB81G7V1g0u2ryquNmsVIOKUAEIDK+3CUjZ6rSRpdvS99dNBnkLFL83qfmtLacGOTIhwQ==",
             "requires": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -24021,8 +24015,7 @@
         "@types/scheduler": {
             "version": "0.16.2",
             "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-            "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-            "dev": true
+            "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
         },
         "@types/serve-index": {
             "version": "1.9.1",
@@ -25863,8 +25856,7 @@
         "csstype": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
-            "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==",
-            "dev": true
+            "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
         },
         "damerau-levenshtein": {
             "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
         "swagger-ui-slim": "^1.0.5",
         "tailwindcss": "^3.1.6",
         "typescript": "^4.7.4",
-        "web-vitals": "^2.1.4"
+        "web-vitals": "^2.1.4",
+        "@types/react": "^18.0.17"
     },
     "scripts": {
         "prestart": "npm run build-server",
@@ -62,7 +63,6 @@
         "@types/jest": "^28.1.7",
         "@types/jsdom": "^20.0.0",
         "@types/node": "^18.7.6",
-        "@types/react": "^18.0.15",
         "@types/react-dom": "^18.0.6",
         "@types/swagger-ui-dist": "^3.30.1",
         "@typescript-eslint/eslint-plugin": "^5.33.1",

--- a/server/lib/types.ts
+++ b/server/lib/types.ts
@@ -1,3 +1,5 @@
+import React from "react";
+
 /* TYPES FOR CLIENT */
 
 export interface Icons {


### PR DESCRIPTION
This is an awful fix and will consider making a change to this.
For now, @types/react is required to finish the tsc build as lib/types has react types.
Only noticed in PROD because it only installed PROD deps.